### PR TITLE
Update google-login-provider.ts

### DIFF
--- a/src/lib/src/providers/google-login-provider.ts
+++ b/src/lib/src/providers/google-login-provider.ts
@@ -78,4 +78,18 @@ export class GoogleLoginProvider extends BaseLoginProvider {
     });
   }
 
+revokeAuth(): Promise<any> {
+ +    return new Promise((resolve, reject) => {
+ +      this.auth2.disconnect().then((err: any) => {
+ +        if (err) {
+ +          reject(err);
+ +        } else {
+ +          resolve();
+ +        }
+ +      });
+ +    });
+ +  }
+ +  
+  }
+
 }


### PR DESCRIPTION
"signOut" disconnect the user but keeps the app authorization binded to the user google account.
"revokeAuth" method calls "disconnect" and gives the user the ability to revoke the authorization from it's google account. In this way he won't need to log into his google account manager and manually revoking it.