### PR TITLE
Fixed README example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,15 +36,24 @@ let config = new AuthServiceConfig([
   }
 ]);
 
+export function provideConfig() {
+  return config;
+}
+
 @NgModule({
   declarations: [
     ...
   ],
   imports: [
     ...
-    SocialLoginModule.initialize(config)
+    SocialLoginModule
   ],
-  providers: [],
+  providers: [
+    {
+      provide: AuthServiceConfig,
+      useFactory: provideConfig
+    }
+  ],
   bootstrap: [...]
 })
 export class AppModule { }


### PR DESCRIPTION
The example in the readme for importing this module doesn't work. The app.module.ts in the demo page (https://abacritt.github.io/angularx-social-login/main.bundle.js) is setup correctly and works though. I made sure by testing the code from the demo in my own app as well. I copied the configuration into this readme.