### PR TITLE
refactor(sociallogin.module.ts): SocialLoginModule refacoring

### DIFF
--- a/src/lib/src/sociallogin.module.ts
+++ b/src/lib/src/sociallogin.module.ts
@@ -1,4 +1,9 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import {
+  NgModule,
+  Optional,
+  SkipSelf,
+  ModuleWithProviders
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { AuthService, AuthServiceConfig } from './auth.service';
@@ -16,7 +21,6 @@ export function configFactory(config: AuthServiceConfig) {
   ]
 })
 export class SocialLoginModule {
-
   public static initialize(config: AuthServiceConfig): ModuleWithProviders {
     return {
       ngModule: SocialLoginModule,
@@ -30,4 +34,10 @@ export class SocialLoginModule {
     };
   }
 
+  constructor(@Optional() @SkipSelf() parentModule: SocialLoginModule) {
+    if (parentModule) {
+      throw new Error(
+        'SocialLoginModule is already loaded. Import it in the AppModule only');
+    }
+  }
 }


### PR DESCRIPTION
The SocialLoginModule should only be included once in an Angular application.

Implementing an error handling logic according to the Angular
documentation at:
https://angular.io/guide/singleton-services#prevent-reimport-of-the-core
module