### PR TITLE
add ready state for providers

### DIFF
--- a/src/lib/src/auth.service.ts
+++ b/src/lib/src/auth.service.ts
@@ -87,20 +87,31 @@ export class AuthService {
 
   private _user: SocialUser = null;
   private _authState: BehaviorSubject<SocialUser> = new BehaviorSubject(null);
+  private _readyState: BehaviorSubject<string[]> = new BehaviorSubject([]);
 
   get authState(): Observable<SocialUser> {
     return this._authState.asObservable();
+  }
+  /** Provides an array of provider ID's as they become ready */
+  get readyState(): Observable<string[]> {
+    return this._readyState.asObservable();
   }
 
   constructor(config: AuthServiceConfig) {
     this.providers = config.providers;
 
     this.providers.forEach((provider: LoginProvider, key: string) => {
-      provider.initialize().then((user: SocialUser) => {
-        user.provider = key;
+      provider.initialize().then(() => {
+        let readyProviders = this._readyState.getValue();
+        readyProviders.push(key);
+        this._readyState.next(readyProviders);
 
-        this._user = user;
-        this._authState.next(user);
+        provider.getLoginStatus().then((user) => {
+          user.provider = key;
+
+          this._user = user;
+          this._authState.next(user);
+        });
       }).catch((err) => {
         // this._authState.next(null);
       });

--- a/src/lib/src/entities/base-login-provider.ts
+++ b/src/lib/src/entities/base-login-provider.ts
@@ -1,18 +1,32 @@
-import { LoginProvider } from "./login-provider";
+import { LoginProvider } from './login-provider';
 import { SocialUser } from './user';
+import { Observable, BehaviorSubject } from 'rxjs';
 
 export abstract class BaseLoginProvider implements LoginProvider {
 
+  protected _readyState: BehaviorSubject<boolean> = new BehaviorSubject(false);
+
   constructor() {}
 
-  abstract initialize(): Promise<SocialUser>;
+  protected onReady(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this._readyState.subscribe((isReady) => {
+        if (isReady) {
+          resolve();
+        }
+      })
+    });
+  }
+
+  abstract initialize(): Promise<void>;
+  abstract getLoginStatus(): Promise<SocialUser>;
   abstract signIn(): Promise<SocialUser>;
   abstract signOut(): Promise<any>;
 
   loadScript(id: string, src: string, onload: any, async = true, inner_text_content = ''): void {
       if (document.getElementById(id)) { return; }
 
-      let signInJS = document.createElement("script");
+      let signInJS = document.createElement('script');
       signInJS.async = async;
       signInJS.src = src;
       signInJS.onload = onload;

--- a/src/lib/src/entities/login-provider.ts
+++ b/src/lib/src/entities/login-provider.ts
@@ -2,7 +2,8 @@ import { SocialUser } from './user';
 import { LoginOpt } from '../auth.service';
 
 export interface LoginProvider {
-  initialize(): Promise<SocialUser>;
+  initialize(): Promise<void>;
+  getLoginStatus(): Promise<SocialUser>;
   signIn(opt?: LoginOpt): Promise<SocialUser>;
   signOut(): Promise<any>;
 }

--- a/src/lib/src/providers/google-login-provider.ts
+++ b/src/lib/src/providers/google-login-provider.ts
@@ -12,7 +12,7 @@ export class GoogleLoginProvider extends BaseLoginProvider {
 
   constructor(private clientId: string, private opt: LoginOpt = {scope: 'email'}) { super(); }
 
-  initialize(): Promise<SocialUser> {
+  initialize(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.loadScript(GoogleLoginProvider.PROVIDER_ID,
         '//apis.google.com/js/platform.js',
@@ -24,22 +24,8 @@ export class GoogleLoginProvider extends BaseLoginProvider {
             });
 
             this.auth2.then(() => {
-              if (this.auth2.isSignedIn.get()) {
-                let user: SocialUser = new SocialUser();
-                let profile = this.auth2.currentUser.get().getBasicProfile();
-                let token = this.auth2.currentUser.get().getAuthResponse(true).access_token;
-                let backendToken = this.auth2.currentUser.get().getAuthResponse(true).id_token;
-
-                user.id = profile.getId();
-                user.name = profile.getName();
-                user.email = profile.getEmail();
-                user.photoUrl = profile.getImageUrl();
-                user.firstName = profile.getGivenName();
-                user.lastName = profile.getFamilyName();
-                user.authToken = token;
-                user.idToken = backendToken;
-                resolve(user);
-              }
+              this._readyState.next(true);
+              resolve();
             }).catch((err: any) => {
               reject(err);
             });
@@ -48,55 +34,84 @@ export class GoogleLoginProvider extends BaseLoginProvider {
     });
   }
 
+  getLoginStatus(): Promise<SocialUser> {
+    return new Promise((resolve, reject) => {
+      this.onReady().then(() => {
+        if (this.auth2.isSignedIn.get()) {
+          let user: SocialUser = new SocialUser();
+          let profile = this.auth2.currentUser.get().getBasicProfile();
+          let token = this.auth2.currentUser.get().getAuthResponse(true).access_token;
+          let backendToken = this.auth2.currentUser.get().getAuthResponse(true).id_token;
+
+          user.id = profile.getId();
+          user.name = profile.getName();
+          user.email = profile.getEmail();
+          user.photoUrl = profile.getImageUrl();
+          user.firstName = profile.getGivenName();
+          user.lastName = profile.getFamilyName();
+          user.authToken = token;
+          user.idToken = backendToken;
+          resolve(user);
+        }
+      });
+    });
+  }
+
   signIn(opt?: LoginOpt): Promise<SocialUser> {
     return new Promise((resolve, reject) => {
-      let promise = this.auth2.signIn(opt);
+      this.onReady().then(() => {
+        let promise = this.auth2.signIn(opt);
 
-      promise.then(() => {
-        let user: SocialUser = new SocialUser();
-        let profile = this.auth2.currentUser.get().getBasicProfile();
-        let token = this.auth2.currentUser.get().getAuthResponse(true).access_token;
-        let backendToken = this.auth2.currentUser.get().getAuthResponse(true).id_token;
+        promise.then(() => {
+          let user: SocialUser = new SocialUser();
+          let profile = this.auth2.currentUser.get().getBasicProfile();
+          let token = this.auth2.currentUser.get().getAuthResponse(true).access_token;
+          let backendToken = this.auth2.currentUser.get().getAuthResponse(true).id_token;
 
-        user.id = profile.getId();
-        user.name = profile.getName();
-        user.email = profile.getEmail();
-        user.photoUrl = profile.getImageUrl();
-        user.firstName = profile.getGivenName();
-        user.lastName = profile.getFamilyName();
-        user.authToken = token;
-        user.idToken = backendToken;
-        resolve(user);
-      }).catch((err: any) => {
-        reject(err);
+          user.id = profile.getId();
+          user.name = profile.getName();
+          user.email = profile.getEmail();
+          user.photoUrl = profile.getImageUrl();
+          user.firstName = profile.getGivenName();
+          user.lastName = profile.getFamilyName();
+          user.authToken = token;
+          user.idToken = backendToken;
+          resolve(user);
+        }).catch((err: any) => {
+          reject(err);
+        });
       });
     });
   }
 
   signOut(): Promise<any> {
     return new Promise((resolve, reject) => {
-      this.auth2.signOut().then((err: any) => {
-        if (err) {
+      this.onReady().then(() => {
+        this.auth2.signOut().then((err: any) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        }).catch((err: any) => {
           reject(err);
-        } else {
-          resolve();
-        }
-      }).catch((err: any) => {
-        reject(err);
+        });
       });
     });
   }
 
   revokeAuth(): Promise<any> {
     return new Promise((resolve, reject) => {
-      this.auth2.disconnect().then((err: any) => {
-        if (err) {
+      this.onReady().then(() => {
+        this.auth2.disconnect().then((err: any) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        }).catch((err: any) => {
           reject(err);
-        } else {
-          resolve();
-        }
-      }).catch((err: any) => {
-        reject(err);
+        });
       });
     });
   }

--- a/src/lib/src/providers/linkedIn-login-provider.ts
+++ b/src/lib/src/providers/linkedIn-login-provider.ts
@@ -12,12 +12,12 @@ export class LinkedInLoginProvider extends BaseLoginProvider {
         super();
     }
 
-    initialize(): Promise<SocialUser> {
+    initialize(): Promise<void> {
         let inner_text = '';
 
         inner_text += 'api_key: ' + this.clientId + '\r\n';
-        inner_text += 'authorize:' +  (this.authorize ? 'true' : 'false') +  '\r\n';
-        inner_text += 'lang: ' + (this.lang ? this.lang : 'fr_FR') +  '\r\n';
+        inner_text += 'authorize:' + (this.authorize ? 'true' : 'false') + '\r\n';
+        inner_text += 'lang: ' + (this.lang ? this.lang : 'fr_FR') + '\r\n';
 
         return new Promise((resolve, reject) => {
             this.loadScript(LinkedInLoginProvider.PROVIDER_ID,
@@ -25,27 +25,38 @@ export class LinkedInLoginProvider extends BaseLoginProvider {
                 () => {
                     let that = this;
                     setTimeout(() => {
-                        that.signIn().then(
-                            user => resolve(user)
-                        )
+                        this._readyState.next(true);
+                        resolve();
                     }, 800);
                 }, false, inner_text);
         });
     }
 
+    getLoginStatus(): Promise<SocialUser> {
+        return new Promise((resolve, reject) => {
+            this.onReady().then(() => {
+                this.signIn().then(
+                    user => resolve(user)
+                )
+            });
+        });
+    }
+
     signIn(): Promise<SocialUser> {
         return new Promise((resolve, reject) => {
-            IN.User.authorize(function() {
-                IN.API.Raw('/people/~:(id,first-name,last-name,email-address,picture-url)').result(function(res: any) {
-                    let user: SocialUser = new SocialUser();
-                    user.id = res.id;
-                    user.name = res.firstName + ' ' + res.lastName;
-                    user.email = res.emailAddress;
-                    user.photoUrl = res.pictureUrl;
-                    user.firstName = res.firstName;
-                    user.lastName = res.lastName;
-                    user.authToken = IN.ENV.auth.oauth_token;
-                    resolve(user);
+            this.onReady().then(() => {
+                IN.User.authorize(function () {
+                    IN.API.Raw('/people/~:(id,first-name,last-name,email-address,picture-url)').result(function (res: any) {
+                        let user: SocialUser = new SocialUser();
+                        user.id = res.id;
+                        user.name = res.firstName + ' ' + res.lastName;
+                        user.email = res.emailAddress;
+                        user.photoUrl = res.pictureUrl;
+                        user.firstName = res.firstName;
+                        user.lastName = res.lastName;
+                        user.authToken = IN.ENV.auth.oauth_token;
+                        resolve(user);
+                    });
                 });
             });
         });
@@ -53,10 +64,11 @@ export class LinkedInLoginProvider extends BaseLoginProvider {
 
     signOut(): Promise<any> {
         return new Promise((resolve, reject) => {
-            IN.User.logout(function() {
-                resolve();
-            }, {});
-
+            this.onReady().then(() => {
+                IN.User.logout(function () {
+                    resolve();
+                }, {});
+            });
         });
     }
 }


### PR DESCRIPTION
Fixes problem with the SDK's not being available yet or `login` functions being called before `init` functions. https://github.com/abacritt/angularx-social-login/issues/93

The error was reported (and experienced myself) only for Facebook, but I believe the error could happen both for Google and Linked In as well and so I made a generic solution for all 3 providers. I've only really tested it for Facebook though.

#### Solution

As you call `AuthService.signIn` or `AuthService.signOut` each provider will internally make sure that the SDK is actually ready before attempting to do the call by using the new `protected onReady(): Promise<void>` in the `BaseLoginProvider`.

#### Bonus

Additionally the `AuthService` will expose a new observable called `readyState` which will emit a string array with the `PROVIDER_ID` of the providers as they become ready. This can be used for local state management (e.g. disable/enable buttons). It is a `BehaviorSubject` so initially an empty array may be received. With all three providers active that means you can get up to 4 results, e.g.:

1) `[]`
2) `["FACEBOOK"]`
3) `["FACEBOOK", "GOOGLE"]`
4) `["FACEBOOK", "GOOGLE", "LINKEDIN"]`

An example of how this can be used:

```javascript
facebookIsReady: false;
googleIsReady: false;
linkedInIsReady: false;

constructor(private authService: AuthService) {
  authService.readyState.subscribe((readyProviders) => {
    this.facebookIsReady = readyProviders.includes(FacebookLoginProvider.PROVIDER_ID);
    this.googleIsReady= readyProviders.includes(GoogleLoginProvider.PROVIDER_ID);
    this.linkedInIsReady= readyProviders.includes(LinkedInLoginProvider.PROVIDER_ID);
  });
}
```