### PR TITLE
add ability to choose which fields to get

### DIFF
--- a/src/lib/src/entities/user.ts
+++ b/src/lib/src/entities/user.ts
@@ -8,4 +8,18 @@ export class SocialUser {
   lastName: string;
   authToken: string;
   idToken: string; // Reference https://developers.google.com/identity/sign-in/web/backend-auth
+
+  /**
+   * Contains the entire object returned from the Facebook API based on the fields you requested.
+   * Only available for the Facebook provider.
+   * Refer to the Graph API for details: https://developers.facebook.com/docs/graph-api
+   */
+  facebook?: any;
+
+  /**
+   * Contains the entire object returned from the Linked In API based on the fields you requested.
+   * Only available for the Linked In provider.
+   * Refer to the Linked In docs: https://developer.linkedin.com/docs/fields
+   */
+  linkedIn?: any;
 }

--- a/src/lib/src/providers/facebook-login-provider.ts
+++ b/src/lib/src/providers/facebook-login-provider.ts
@@ -9,8 +9,10 @@ export class FacebookLoginProvider extends BaseLoginProvider {
   public static readonly PROVIDER_ID = 'FACEBOOK';
 
   constructor(
-    private clientId: string, private opt: LoginOpt = { scope: 'email,public_profile'},
-    private locale: string = 'en_US'
+    private clientId: string,
+    private opt: LoginOpt = { scope: 'email,public_profile' },
+    private locale: string = 'en_US',
+    private fields: string = 'name,email,picture,first_name,last_name'
   ) { super(); }
 
   initialize(): Promise<void> {
@@ -39,7 +41,7 @@ export class FacebookLoginProvider extends BaseLoginProvider {
         FB.getLoginStatus(function (response: any) {
           if (response.status === 'connected') {
             let authResponse = response.authResponse;
-            FB.api('/me?fields=name,email,picture,first_name,last_name', (fbUser: any) => {
+            FB.api(`/me?fields=${this.fields}`, (fbUser: any) => {
               let user: SocialUser = new SocialUser();
 
               user.id = fbUser.id;
@@ -49,6 +51,8 @@ export class FacebookLoginProvider extends BaseLoginProvider {
               user.firstName = fbUser.first_name;
               user.lastName = fbUser.last_name;
               user.authToken = authResponse.accessToken;
+
+              user.facebook = fbUser;
 
               resolve(user);
             });
@@ -58,13 +62,13 @@ export class FacebookLoginProvider extends BaseLoginProvider {
     });
   }
 
-  signIn(): Promise<SocialUser> {
+  signIn(opt?: LoginOpt): Promise<SocialUser> {
     return new Promise((resolve, reject) => {
       this.onReady().then(() => {
         FB.login((response: any) => {
           if (response.authResponse) {
             let authResponse = response.authResponse;
-            FB.api('/me?fields=name,email,picture,first_name,last_name', (fbUser: any) => {
+            FB.api(`/me?fields=${this.fields}`, (fbUser: any) => {
               let user: SocialUser = new SocialUser();
 
               user.id = fbUser.id;
@@ -74,6 +78,8 @@ export class FacebookLoginProvider extends BaseLoginProvider {
               user.firstName = fbUser.first_name;
               user.lastName = fbUser.last_name;
               user.authToken = authResponse.accessToken;
+
+              user.facebook = fbUser;
 
               resolve(user);
             });

--- a/src/lib/src/providers/linkedIn-login-provider.ts
+++ b/src/lib/src/providers/linkedIn-login-provider.ts
@@ -8,7 +8,12 @@ export class LinkedInLoginProvider extends BaseLoginProvider {
 
     public static readonly PROVIDER_ID: string = 'LINKEDIN';
 
-    constructor(private clientId: string, private authorize?: boolean, private lang?: string) {
+    constructor(
+        private clientId: string,
+        private authorize?: boolean,
+        private lang?: string,
+        private fields: string = 'id,first-name,last-name,email-address,picture-url'
+    ) {
         super();
     }
 
@@ -46,7 +51,7 @@ export class LinkedInLoginProvider extends BaseLoginProvider {
         return new Promise((resolve, reject) => {
             this.onReady().then(() => {
                 IN.User.authorize(function () {
-                    IN.API.Raw('/people/~:(id,first-name,last-name,email-address,picture-url)').result(function (res: any) {
+                    IN.API.Raw(`/people/~:(${this.fields})`).result(function (res: any) {
                         let user: SocialUser = new SocialUser();
                         user.id = res.id;
                         user.name = res.firstName + ' ' + res.lastName;
@@ -55,6 +60,9 @@ export class LinkedInLoginProvider extends BaseLoginProvider {
                         user.firstName = res.firstName;
                         user.lastName = res.lastName;
                         user.authToken = IN.ENV.auth.oauth_token;
+
+                        user.linkedIn = res;
+
                         resolve(user);
                     });
                 });


### PR DESCRIPTION
Fixes https://github.com/abacritt/angularx-social-login/issues/100 for Facebook and Linked In.

```typescript
new AuthServiceConfig([{
  id: FacebookLoginProvider.PROVIDER_ID,
  provider: new FacebookLoginProvider(
    'Facebook-App-Id',
    { scope: 'email,user_age_range' },
    'en_US',
    'name,email,picture,first_name,last_name,age_range' // this parameter is new
  )
}]);
```

The resulting SocialUser will now contain the entire resulting object in the property `facebook` or `linkedIn` respectively.

```typescript
this.authService.signIn(FacebookLoginProvider.PROVIDER_ID).then((user: SocialUser) => {
  console.log(user.facebook.age_range); // { "min": 21 }
});
```
This example shows Facebook only, but Linked In works exactly the same way.

However, this PR does **not** include Google as their API seems to work completely differently. I suppose we could expose the result of `this.auth2.currentUser.get()`, but it didn't seem right to me, so I didn't.