### PR TITLE
Load Google platform.js over HTTPS

### DIFF
--- a/src/lib/src/providers/google-login-provider.ts
+++ b/src/lib/src/providers/google-login-provider.ts
@@ -15,7 +15,7 @@ export class GoogleLoginProvider extends BaseLoginProvider {
   initialize(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.loadScript(GoogleLoginProvider.PROVIDER_ID,
-        '//apis.google.com/js/platform.js',
+        'https://apis.google.com/js/platform.js',
         () => {
           gapi.load('auth2', () => {
             this.auth2 = gapi.auth2.init({


### PR DESCRIPTION
apis.google.com uses HSTS; the JS must be loaded over HTTPS.

It is insecure to load JS over plain HTTP anyway.