### PR TITLE
{bug} Reject getLoginStatus when no user is logged in

### DIFF
--- a/src/lib/src/auth.service.ts
+++ b/src/lib/src/auth.service.ts
@@ -111,9 +111,9 @@ export class AuthService {
 
           this._user = user;
           this._authState.next(user);
+        }).catch((err) => {
+          this._authState.next(null);
         });
-      }).catch((err) => {
-        // this._authState.next(null);
       });
     });
   }

--- a/src/lib/src/providers/facebook-login-provider.ts
+++ b/src/lib/src/providers/facebook-login-provider.ts
@@ -57,6 +57,8 @@ export class FacebookLoginProvider extends BaseLoginProvider {
 
                             resolve(user);
                         });
+                    } else {
+                        reject('No user is currently logged in.');
                     }
                 });
             });

--- a/src/lib/src/providers/google-login-provider.ts
+++ b/src/lib/src/providers/google-login-provider.ts
@@ -52,6 +52,8 @@ export class GoogleLoginProvider extends BaseLoginProvider {
                     user.authToken = token;
                     user.idToken = backendToken;
                     resolve(user);
+                } else {
+                    reject('No user is currently logged in.');
                 }
             });
         });

--- a/src/lib/src/providers/linkedIn-login-provider.ts
+++ b/src/lib/src/providers/linkedIn-login-provider.ts
@@ -54,6 +54,8 @@ export class LinkedInLoginProvider extends BaseLoginProvider {
 
                         resolve(user);
                     });
+                } else {
+                    reject('No user is currently logged in.');
                 }
             });
         });


### PR DESCRIPTION
Rejecting the getLoginStatus in each provider when a user is not logged allows to react on this when a user is fetching the authState when the application is bootstrapped for the first time.

Fixes #154