### PR TITLE
Adding Type to PROVIDER_ID

### DIFF
--- a/src/lib/src/providers/facebook-login-provider.ts
+++ b/src/lib/src/providers/facebook-login-provider.ts
@@ -6,7 +6,7 @@ declare let FB: any;
 
 export class FacebookLoginProvider extends BaseLoginProvider {
 
-    public static readonly PROVIDER_ID = 'FACEBOOK';
+    public static readonly PROVIDER_ID: string = 'FACEBOOK';
 
     constructor(
         private clientId: string,


### PR DESCRIPTION
Since type is not defined, the previous version of Typescript complains as 
"error TS1039: Initializers are not allowed in ambient contexts."