### PR TITLE
#240 Add Apple Signin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ export { AuthService, LoginOpt } from './lib/auth.service';
 export { SocialLoginModule } from './lib/sociallogin.module';
 export { SocialUser } from './lib/entities/user';
 export { GoogleLoginProvider } from './lib/providers/google-login-provider';
+export { AppleLoginProvider } from './lib/providers/apple-login-provider';
 export { FacebookLoginProvider } from './lib/providers/facebook-login-provider';
 export { AuthServiceConfig } from './lib/auth.service';

--- a/src/lib/providers/apple-login-provider.ts
+++ b/src/lib/providers/apple-login-provider.ts
@@ -1,0 +1,44 @@
+import { BaseLoginProvider } from '../entities/base-login-provider';
+import { SocialUser } from '../entities/user';
+import { LoginOpt } from '../auth.service';
+
+declare let AppleID: any;
+
+export class AppleLoginProvider extends BaseLoginProvider {
+
+    public static readonly PROVIDER_ID: string = 'APPLE';
+
+    protected auth2: any;
+
+    constructor(private clientId: string, private scope: string, private redirectURI: string) { super(); }
+
+    initialize(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.loadScript(AppleLoginProvider.PROVIDER_ID,
+                'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js',
+                () => {
+                        this.auth2 = AppleID.auth.init({
+                            clientId : this.clientId,
+                            scope : this.scope,
+                            redirectURI: this.redirectURI
+                        });
+                });
+        });
+    }
+
+    signIn(opt?: LoginOpt): Promise<SocialUser> {
+        console.log("AppleCall Signin");
+        return new Promise((resolve, reject) => {
+                let promise = AppleID.auth.signIn();
+                promise.then((err: any) => {
+                    reject(err);
+                });
+        });
+    }
+getLoginStatus(): Promise<SocialUser> {
+        return null;
+    }
+signOut(revoke?: boolean): Promise<any> {
+        return null;
+    }
+}


### PR DESCRIPTION
Apple.js use callback Post to send User Information.
You must have a new Endpoint

Init in your App.module
{
    id: AppleLoginProvider.PROVIDER_ID,
    provider: new AppleLoginProvider('[CLIENT_ID]','name email', '[REDIRECT_URI]')
 }