### PR TITLE
Simple DummyLoginProvider

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,9 @@
 # Angular 8 Social Login
 
-Social login and authentication module for Angular 8 (supports Angular 4+). Supports authentication with **Google** and **Facebook**. Can be extended to other providers also.
+Social login and authentication module for Angular 8 (supports Angular 4+). Supports authentication with **Google** and **Facebook**. 
+Can be extended to other providers also.
+
+Includes a **Dummy** login provider for development purposes.
 
 Check out the [demo](https://abacritt.github.io/angularx-social-login/).
 

--- a/README.MD
+++ b/README.MD
@@ -163,3 +163,59 @@ cd demo
 npm install
 ng serve
 ```
+
+## Dummy provider
+
+There is also a `DummyLoginProvider`, which simulates login / logout without actually 
+requiring an Internet connection.  Useful for certain development situations.
+
+### Usage
+
+#### Simple use case
+
+Just add the `DummyLoginProvider` to your `AuthServiceConfig()` as described above
+and then follow the same model as the other providers.
+
+```
+let config = new AuthServiceConfig([
+  { ... },
+  {
+      id: DummyLoginProvider.PROVIDER_ID,
+      provider: new DummyLoginProvider()
+  },
+  { ... }
+]);
+```
+
+#### Bring your own user
+
+The simple model hard-wires a certain caertoon rodent as the authenticated user. 
+
+If you would like to control the authenticated user identity, you can pass an
+optional `SocialUser` object into the constructor.
+
+For example, if you want to simulate the greatest football referee England has ever produced:
+
+```
+const dummyUser: SocialUser = {
+    id: '0123456789',
+    name: 'Howard Webb',
+    email: 'howard@webb.com',
+    firstName: 'Howard',
+    lastName: 'Webb',
+    authToken: 'dummyAuthToken',
+    photoUrl: 'https://en.wikipedia.org/wiki/Howard_Webb#/media/File:Howard_Webb_march11.jpg',
+    provider: 'DUMMY',
+    idToken: 'dummyIdToken',
+    authorizationCode: 'dummyAuthCode'
+};
+
+let config = new AuthServiceConfig([
+  { ... },
+  {
+      id: DummyLoginProvider.PROVIDER_ID,
+      provider: new DummyLoginProvider(dummyUser)  // Pass your user into the constructor
+  },
+  { ... }
+]);
+```

--- a/README.MD
+++ b/README.MD
@@ -192,7 +192,7 @@ let config = new AuthServiceConfig([
 
 #### Bring your own user
 
-The simple model hard-wires a certain caertoon rodent as the authenticated user. 
+The simple model hard-wires a certain cartoon rodent as the authenticated user. 
 
 If you would like to control the authenticated user identity, you can pass an
 optional `SocialUser` object into the constructor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angularx-social-login",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ export { SocialLoginModule } from './lib/sociallogin.module';
 export { SocialUser } from './lib/entities/user';
 export { GoogleLoginProvider } from './lib/providers/google-login-provider';
 export { FacebookLoginProvider } from './lib/providers/facebook-login-provider';
+export { DummyLoginProvider } from './lib/providers/dummy-login-provider';
 export { AuthServiceConfig } from './lib/auth.service';

--- a/src/lib/providers/dummy-login-provider.ts
+++ b/src/lib/providers/dummy-login-provider.ts
@@ -22,6 +22,8 @@ export class DummyLoginProvider extends BaseLoginProvider {
 
     private dummy: SocialUser;
 
+    private loggedIn: boolean;
+
     constructor(dummy?: SocialUser) {
         super();
         if (dummy) {
@@ -29,12 +31,20 @@ export class DummyLoginProvider extends BaseLoginProvider {
         } else {
             this.dummy = DummyLoginProvider.DEFAULT_USER;
         }
+
+        // Start not logged in
+        this.loggedIn = false;
     }
 
     getLoginStatus(): Promise<SocialUser> {
         return new Promise((resolve, reject) => {
             this.onReady().then(() => {
+
+                if (this.loggedIn) {
                     resolve(this.dummy);
+                } else {
+                    reject('No user is currently logged in.');
+                }
             });
         });
     }
@@ -49,6 +59,7 @@ export class DummyLoginProvider extends BaseLoginProvider {
     signIn(opt ?: LoginOpt): Promise<SocialUser> {
         return new Promise((resolve, reject) => {
             this.onReady().then(() => {
+                this.loggedIn = true;
                 resolve(this.dummy);
             });
         });
@@ -57,6 +68,7 @@ export class DummyLoginProvider extends BaseLoginProvider {
     signOut(revoke ?: boolean): Promise<any> {
         return new Promise((resolve, reject) => {
             this.onReady().then(() => {
+                this.loggedIn = false;
                 resolve();
             });
         });

--- a/src/lib/providers/dummy-login-provider.ts
+++ b/src/lib/providers/dummy-login-provider.ts
@@ -1,0 +1,61 @@
+import {LoginOpt, SocialUser} from 'angularx-social-login';
+
+export class DummyLoginProvider extends BaseLoginProvider {
+
+    public static readonly PROVIDER_ID: string = 'DUMMY';
+
+    static readonly DEFAULT_USER = {
+        id: '1234567890',
+        name: 'Mickey Mouse',
+        email: 'mickey@mouse.com',
+        firstName: 'Mickey',
+        lastName: 'Mouse',
+        authToken: 'dummyAuthToken',
+        photoUrl: 'https://en.wikipedia.org/wiki/File:Mickey_Mouse.png',
+        provider: 'DUMMY',
+        idToken: 'dummyIdToken',
+        authorizationCode: 'dummyAuthCode'
+    };
+
+    private dummy: SocialUser;
+
+    constructor(dummy?: SocialUser) {
+        super();
+        if (dummy) {
+            this.dummy = dummy;
+        } else {
+            this.dummy = DummyLoginProvider.DEFAULT_USER;
+        }
+    }
+
+    getLoginStatus(): Promise<SocialUser> {
+        return new Promise((resolve, reject) => {
+            this.onReady().then(() => {
+                    resolve(this.dummy);
+            });
+        });
+    }
+
+    initialize(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this._readyState.next(true);
+            resolve();
+        });
+    }
+
+    signIn(opt ?: LoginOpt): Promise<SocialUser> {
+        return new Promise((resolve, reject) => {
+            this.onReady().then(() => {
+                resolve(this.dummy);
+            });
+        });
+    }
+
+    signOut(revoke ?: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.onReady().then(() => {
+                resolve();
+            });
+        });
+    }
+}

--- a/src/lib/providers/dummy-login-provider.ts
+++ b/src/lib/providers/dummy-login-provider.ts
@@ -1,4 +1,7 @@
-import {LoginOpt, SocialUser} from 'angularx-social-login';
+
+import {BaseLoginProvider} from '../entities/base-login-provider';
+import {SocialUser} from '../entities/user';
+import {LoginOpt} from '../auth.service';
 
 export class DummyLoginProvider extends BaseLoginProvider {
 

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -1,3 +1,4 @@
 
 export { GoogleLoginProvider } from './google-login-provider';
 export { FacebookLoginProvider } from './facebook-login-provider';
+export { DummyLoginProvider } from './dummy-login-provider';


### PR DESCRIPTION
A login provider that simulates a social login without requiring remote network access or application registration with any third party authentication provider.  Allows custom configuration of dummy authenticated user details.