### PR TITLE
feat: add optional errorCallback

### DIFF
--- a/projects/lib/src/socialauth.service.ts
+++ b/projects/lib/src/socialauth.service.ts
@@ -6,6 +6,7 @@ import { SocialUser } from './entities/social-user';
 export interface SocialAuthServiceConfig {
   autoLogin?: boolean;
   providers: { id: string; provider: LoginProvider }[];
+  errorCallback?(error: any): void;
 }
 
 /** @dynamic */
@@ -88,7 +89,12 @@ export class SocialAuthService {
           });
         }
       })
-      .catch(console.error);
+      .catch(error => {
+        console.error(error);
+        if (config.errorCallback) {
+          config.errorCallback(error);
+        }
+      });
   }
 
   signIn(providerId: string, signInOptions?: any): Promise<SocialUser> {

--- a/projects/lib/src/socialauth.service.ts
+++ b/projects/lib/src/socialauth.service.ts
@@ -6,7 +6,7 @@ import { SocialUser } from './entities/social-user';
 export interface SocialAuthServiceConfig {
   autoLogin?: boolean;
   providers: { id: string; provider: LoginProvider }[];
-  errorCallback?(error: any): void;
+  onError?(error: any): void;
 }
 
 /** @dynamic */
@@ -91,8 +91,8 @@ export class SocialAuthService {
       })
       .catch(error => {
         console.error(error);
-        if (config.errorCallback) {
-          config.errorCallback(error);
+        if (config.onError) {
+          config.onError(error);
         }
       });
   }


### PR DESCRIPTION
With google or other providers you can get following error when you are browsing in private modus:
```error: "idpiframe_initialization_failed", details: "Cookies are not enabled in current environment."```

In this case I want to inform the user instead of having a silence error. My proposal is to add an erroCallback, where you can add an alert or something else to avoid that the user is not informed.
