### PR TITLE
Emit initState event

### DIFF
--- a/projects/lib/src/socialauth.service.ts
+++ b/projects/lib/src/socialauth.service.ts
@@ -60,8 +60,8 @@ export class SocialAuthService {
     )
       .then(() => {
         this.initialized = true;
+        this._initState.next(this.initialized);
         this._initState.complete();
-
 
         if (this.autoLogin) {
           const loginStatusPromises = [];


### PR DESCRIPTION
It's not intuitive and makes some restrictions when you do not emit this event.

1 - **Subscribe** on this subject never fires. And you need to use a **finalize** pipe and leave an empty subscribe to get the state of observable. It's a little bit redundant code.

```
this.socialAuthService.initState
  .pipe(finalize(() => this.socialAuthServiceInitialized = true))
  .subscribe();
```

2 - You can't use it in angular **async** pipe. For example:

```
<button type="button" [disabled]="disabled || !(socialAuthService.initState | async)">Continue with Facebook</button>
```