### PR TITLE
hotfix/280-login-provider-ready

### DIFF
--- a/projects/lib/src/entities/base-login-provider.ts
+++ b/projects/lib/src/entities/base-login-provider.ts
@@ -1,6 +1,5 @@
 import { LoginProvider } from './login-provider';
 import { SocialUser } from './social-user';
-import { BehaviorSubject } from 'rxjs';
 
 export abstract class BaseLoginProvider implements LoginProvider {
   constructor() {}

--- a/projects/lib/src/providers/amazon-login-provider.ts
+++ b/projects/lib/src/providers/amazon-login-provider.ts
@@ -32,14 +32,18 @@ export class AmazonLoginProvider extends BaseLoginProvider {
     };
 
     return new Promise((resolve, reject) => {
-      this.loadScript(
-        'amazon-login-sdk',
-        'https://assets.loginwithamazon.com/sdk/na/login1.js',
-        () => {
-          resolve();
-        },
-        amazonRoot
-      );
+      try {
+        this.loadScript(
+          'amazon-login-sdk',
+          'https://assets.loginwithamazon.com/sdk/na/login1.js',
+          () => {
+            resolve();
+          },
+          amazonRoot
+        );
+      } catch (err) {
+        reject(err);
+      }
     });
   }
 

--- a/projects/lib/src/providers/facebook-login-provider.ts
+++ b/projects/lib/src/providers/facebook-login-provider.ts
@@ -20,21 +20,25 @@ export class FacebookLoginProvider extends BaseLoginProvider {
 
   initialize(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.loadScript(
-        FacebookLoginProvider.PROVIDER_ID,
-        `//connect.facebook.net/${this.initOptions.locale}/sdk.js`,
-        () => {
-          FB.init({
-            appId: this.clientId,
-            autoLogAppEvents: true,
-            cookie: true,
-            xfbml: true,
-            version: this.initOptions.version,
-          });
+      try {
+        this.loadScript(
+          FacebookLoginProvider.PROVIDER_ID,
+          `//connect.facebook.net/${this.initOptions.locale}/sdk.js`,
+          () => {
+            FB.init({
+              appId: this.clientId,
+              autoLogAppEvents: true,
+              cookie: true,
+              xfbml: true,
+              version: this.initOptions.version,
+            });
 
-          resolve();
-        }
-      );
+            resolve();
+          }
+        );
+      } catch (err) {
+        reject(err);
+      }
     });
   }
 

--- a/projects/lib/src/providers/google-login-provider.ts
+++ b/projects/lib/src/providers/google-login-provider.ts
@@ -17,26 +17,30 @@ export class GoogleLoginProvider extends BaseLoginProvider {
 
   initialize(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.loadScript(
-        GoogleLoginProvider.PROVIDER_ID,
-        'https://apis.google.com/js/platform.js',
-        () => {
-          gapi.load('auth2', () => {
-            this.auth2 = gapi.auth2.init({
-              ...this.initOptions,
-              client_id: this.clientId,
-            });
-
-            this.auth2
-              .then(() => {
-                resolve();
-              })
-              .catch((err: any) => {
-                reject(err);
+      try {
+        this.loadScript(
+          GoogleLoginProvider.PROVIDER_ID,
+          'https://apis.google.com/js/platform.js',
+          () => {
+            gapi.load('auth2', () => {
+              this.auth2 = gapi.auth2.init({
+                ...this.initOptions,
+                client_id: this.clientId,
               });
-          });
-        }
-      );
+
+              this.auth2
+                .then(() => {
+                  resolve();
+                })
+                .catch((err: any) => {
+                  reject(err);
+                });
+            });
+          }
+        );
+      } catch (err) {
+        reject(err);
+      }
     });
   }
 
@@ -63,7 +67,9 @@ export class GoogleLoginProvider extends BaseLoginProvider {
 
         resolve(user);
       } else {
-        reject(`No user is currently logged in with ${GoogleLoginProvider.PROVIDER_ID}`);
+        reject(
+          `No user is currently logged in with ${GoogleLoginProvider.PROVIDER_ID}`
+        );
       }
     });
   }

--- a/projects/lib/src/providers/vk-login-provider.ts
+++ b/projects/lib/src/providers/vk-login-provider.ts
@@ -21,17 +21,21 @@ export class VKLoginProvider extends BaseLoginProvider {
 
   initialize(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.loadScript(
-        VKLoginProvider.PROVIDER_ID,
-        this.VK_API_URL,
-        () => {
-          VK.init({
-            apiId: this.clientId,
-          });
+      try {
+        this.loadScript(
+          VKLoginProvider.PROVIDER_ID,
+          this.VK_API_URL,
+          () => {
+            VK.init({
+              apiId: this.clientId,
+            });
 
-          resolve();
-        }
-      );
+            resolve();
+          }
+        );
+      } catch (err) {
+        reject(err);
+      }
     });
   }
 

--- a/projects/lib/src/socialauth.service.ts
+++ b/projects/lib/src/socialauth.service.ts
@@ -15,7 +15,8 @@ export class SocialAuthService {
   private static readonly ERR_LOGIN_PROVIDER_NOT_FOUND =
     'Login provider not found';
   private static readonly ERR_NOT_LOGGED_IN = 'Not logged in';
-  private static readonly ERR_NOT_INITIALIZED = 'Login providers not ready yet. Are there errors on your console?';
+  private static readonly ERR_NOT_INITIALIZED =
+    'Login providers not ready yet. Are there errors on your console?';
 
   private providers: Map<string, LoginProvider> = new Map();
   private autoLogin = false;
@@ -23,6 +24,7 @@ export class SocialAuthService {
   private _user: SocialUser = null;
   private _authState: ReplaySubject<SocialUser> = new ReplaySubject(1);
 
+  /* Consider making this an enum comprising LOADING, LOADED, FAILED etc. */
   private initialized = false;
   private _initState: AsyncSubject<boolean> = new AsyncSubject();
 
@@ -36,7 +38,7 @@ export class SocialAuthService {
 
   constructor(
     @Inject('SocialAuthServiceConfig')
-      config: SocialAuthServiceConfig | Promise<SocialAuthServiceConfig>,
+    config: SocialAuthServiceConfig | Promise<SocialAuthServiceConfig>
   ) {
     if (config instanceof Promise) {
       config.then((config) => {
@@ -49,7 +51,7 @@ export class SocialAuthService {
 
   private initialize(config: SocialAuthServiceConfig) {
     this.autoLogin = config.autoLogin !== undefined ? config.autoLogin : false;
-    const {onError = console.error} = config;
+    const { onError = console.error } = config;
 
     config.providers.forEach((item) => {
       this.providers.set(item.id, item.provider);
@@ -57,14 +59,10 @@ export class SocialAuthService {
 
     Promise.all(
       Array.from(this.providers.values()).map((provider) =>
-        provider.initialize(),
-      ),
+        provider.initialize()
+      )
     )
       .then(() => {
-        this.initialized = true;
-        this._initState.next(this.initialized);
-        this._initState.complete();
-
         if (this.autoLogin) {
           const loginStatusPromises = [];
           let loggedIn = false;
@@ -90,8 +88,13 @@ export class SocialAuthService {
           });
         }
       })
-      .catch(error => {
+      .catch((error) => {
         onError(error);
+      })
+      .finally(() => {
+        this.initialized = true;
+        this._initState.next(this.initialized);
+        this._initState.complete();
       });
   }
 


### PR DESCRIPTION
Major change is to set `initialized` to `true` even when the `Promise.all` in `SocialAuthService#initialize` rejects. This would mean other providers will still be usable, while the providers that failed to load would behave erratically (would not fail gracefully).