### PR TITLE
Microsoft Login Provider

### DIFF
--- a/projects/lib/src/providers/microsoft-login-provider.ts
+++ b/projects/lib/src/providers/microsoft-login-provider.ts
@@ -1,0 +1,252 @@
+import { BaseLoginProvider } from '../entities/base-login-provider';
+import { SocialUser } from '../entities/social-user';
+
+/**
+ * Protocol modes supported by MSAL.
+ */
+export enum ProtocolMode {
+  AAD = 'AAD',
+  OIDC = 'OIDC'
+}
+
+/**
+ * Initialization Options for Microsoft Provider: https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md
+ * Details (not all options are supported): https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/configuration.md
+ */
+export type MicrosoftOptions = {
+  redirect_uri: string,
+  authority?: string,
+  knownAuthorities?: string[],
+  protocolMode?: ProtocolMode,
+  clientCapabilities?: string[],
+  cacheLocation?: string,
+  scopes?: string[]
+};
+
+// Collection of internal MSAL interfaces from: https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-browser/src
+
+interface MSALAccount {
+  environment: string;
+  homeAccountId: string;
+  tenantId: string;
+  username: string;
+}
+
+interface MSGraphUserInfo {
+  businessPhones: string[];
+  displayName: string;
+  givenName: string;
+  id: string;
+  jobTitle: string;
+  mail: string;
+  mobilePhone: string;
+  officeLocation: string;
+  preferredLanguage: string;
+  surname: string;
+  userPrincipalName: string;
+}
+
+interface MSALLoginRequest {
+  scopes?: string[];
+  sid?: string;
+  loginHint?: string;
+  domainHint?: string;
+}
+
+interface MSALLoginResponse {
+  accessToken: string;
+  account: MSALAccount;
+  expiresOn: Date;
+  extExpiresOn: Date;
+  familyId: string;
+  fromCache: boolean;
+  idToken: string;
+  idTokenClaims: any;
+  scopes: string[];
+  state: string;
+  tenantId: string;
+  uniqueId: string;
+}
+
+interface MSALLogoutRequest {
+  account?: MSALAccount;
+  postLogoutRedirectUri?: string;
+  authority?: string;
+  correlationId?: string;
+}
+
+interface MSALClientApplication {
+  getAllAccounts(): MSALAccount[];
+  logout(logoutRequest?: MSALLogoutRequest): Promise<void>;
+  loginPopup(loginRequest: MSALLoginRequest): Promise<MSALLoginResponse>;
+  ssoSilent(loginRequest: MSALLoginRequest): Promise<MSALLoginResponse>;
+  acquireTokenSilent(loginRequest: MSALLoginRequest): Promise<MSALLoginResponse>;
+  getAccountByHomeId(homeAccountId: string): MSALAccount;
+}
+
+declare let msal: any;
+
+const COMMON_AUTHORITY: string = 'https://login.microsoftonline.com/common/';
+
+const defaultOptions : MicrosoftOptions = {
+  redirect_uri: location.origin,
+  authority: COMMON_AUTHORITY,
+  scopes: ['openid', 'profile', 'User.Read'],
+  knownAuthorities: [],
+  protocolMode: ProtocolMode.AAD,
+  clientCapabilities: [],
+  cacheLocation: 'sessionStorage'
+};
+
+/**
+ * Microsoft Authentication using MSAL v2: https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-browser
+ */
+export class MicrosoftLoginProvider extends BaseLoginProvider {
+  private _instance: MSALClientApplication;
+  public static readonly PROVIDER_ID: string = 'MICROSOFT';
+
+  constructor(
+    private clientId: string,
+    private initOptions: MicrosoftOptions = defaultOptions
+  ) {
+    super();
+  }
+
+  initialize(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.loadScript(
+        MicrosoftLoginProvider.PROVIDER_ID,
+        'https://alcdn.msauth.net/browser/2.1.0/js/msal-browser.js',
+        () => {
+          try {
+            const config = {
+              auth: {
+                clientId: this.clientId,
+                redirectUri: this.initOptions.redirect_uri ?? defaultOptions.redirect_uri,
+                authority: this.initOptions.authority ?? defaultOptions.authority,
+                knownAuthorities: this.initOptions.knownAuthorities ?? defaultOptions.knownAuthorities,
+                protocolMode: this.initOptions.protocolMode ?? defaultOptions.protocolMode,
+                clientCapabilities: this.initOptions.clientCapabilities ?? defaultOptions.clientCapabilities
+              },
+              cache: !this.initOptions.cacheLocation ? null : {
+                cacheLocation: this.initOptions.cacheLocation ?? defaultOptions.cacheLocation
+              }
+            };
+
+            this._instance = new msal.PublicClientApplication(config);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        }
+      );
+    });
+  }
+
+  private getSocialUser(loginResponse): Promise<SocialUser> {
+    return new Promise<SocialUser>((resolve, reject) => {
+      //After login, use Microsoft Graph API to get user info
+      let meRequest = new XMLHttpRequest();
+      meRequest.onreadystatechange = () => {
+        if (meRequest.readyState == 4) {
+          try {
+            if (meRequest.status == 200) {
+              let userInfo = <MSGraphUserInfo>JSON.parse(meRequest.responseText);
+
+              let user: SocialUser = new SocialUser();
+              user.provider = MicrosoftLoginProvider.PROVIDER_ID;
+              user.id = loginResponse.idToken;
+              user.name = loginResponse.idTokenClaims.name;
+              user.email = loginResponse.account.username;
+              user.idToken = loginResponse.idToken;
+              user.response = loginResponse;
+              user.firstName = userInfo.givenName;
+              user.lastName = userInfo.surname;
+
+              resolve(user);
+            } else {
+              reject(`Error retrieving user info: ${meRequest.status}`);
+            }
+          } catch (err) {
+            reject(err);
+          }
+        }
+      };
+
+      //Microsoft Graph ME Endpoint: https://docs.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http
+      meRequest.open('GET', 'https://graph.microsoft.com/v1.0/me');
+      meRequest.setRequestHeader('Authorization', `Bearer ${loginResponse.accessToken}`);
+      try {
+        meRequest.send();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  getLoginStatus(): Promise<SocialUser> {
+    return new Promise<SocialUser>((resolve, reject) => {
+      const accounts = this._instance.getAllAccounts();
+      if (accounts.length > 0) {
+        try {
+          this._instance.ssoSilent({
+            scopes: this.initOptions.scopes,
+            loginHint: accounts[0].username
+          })
+            .then(loginResponse => {
+              this.getSocialUser(loginResponse)
+                .then(user => resolve(user))
+                .catch(err => reject(err));
+            })
+            .catch(err => reject(err));
+        } catch (err) {
+          reject(err);
+        }
+      } else {
+        reject(`No user is currently logged in with ${MicrosoftLoginProvider.PROVIDER_ID}`);
+      }
+    });
+  }
+
+  signIn(): Promise<SocialUser> {
+    return new Promise<SocialUser>((resolve, reject) => {
+      try {
+        this._instance.loginPopup({
+          scopes: this.initOptions.scopes
+        })
+          .then(loginResponse => {
+            this.getSocialUser(loginResponse)
+              .then(user => resolve(user))
+              .catch(err => reject(err));
+          })
+          .catch(err => reject(err));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  signOut(revoke?: boolean): Promise<any> {
+    return new Promise<any>((resolve, reject) => {
+      try {
+        const accounts = this._instance.getAllAccounts();
+        //TODO: This redirects to a Microsoft page, then sends us back to redirect_uri... this doesn't seem to match other providers
+        //Open issues:
+        // https://github.com/abacritt/angularx-social-login/issues/306
+        // https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/2563
+        this._instance.logout({
+          account: accounts[0],
+          postLogoutRedirectUri: this.initOptions.redirect_uri
+        })
+          .then(() => {
+            resolve();
+          })
+          .catch(err => {
+            reject(err);
+          });
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+}

--- a/projects/lib/src/public-api.ts
+++ b/projects/lib/src/public-api.ts
@@ -11,3 +11,4 @@ export { GoogleLoginProvider } from './providers/google-login-provider';
 export { FacebookLoginProvider } from './providers/facebook-login-provider';
 export { AmazonLoginProvider } from './providers/amazon-login-provider';
 export { VKLoginProvider } from './providers/vk-login-provider';
+export { MicrosoftLoginProvider } from './providers/microsoft-login-provider';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,8 @@ import {
   GoogleLoginProvider,
   FacebookLoginProvider,
   AmazonLoginProvider,
-  VKLoginProvider
+  VKLoginProvider,
+  MicrosoftLoginProvider
 } from 'lib';
 
 @NgModule({
@@ -46,10 +47,14 @@ import {
               '7624815'
             ),
           },
+          {
+            id: MicrosoftLoginProvider.PROVIDER_ID,
+            provider: new MicrosoftLoginProvider('0611ccc3-9521-45b6-b432-039852002705'),
+          }
         ],
       } as SocialAuthServiceConfig,
     }
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule { }

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -8,10 +8,11 @@
       <p class="card-text">Sign in with</p>
     </div>
     <div class="card-block">
-      <button class="btn btn-social-icon btn-google mx-1" (click)="signInWithGoogle()"><span class="fa fa-google"></span></button>
-      <button class="btn btn-social-icon btn-facebook mx-1" (click)="signInWithFB()"><span class="fa fa-facebook"></span></button>
-      <button class="btn btn-social-icon btn-amazon mx-1" (click)="signInWithAmazon()"><span class="fa fa-amazon"></span></button>
-      <button class="btn btn-social-icon btn-amazon mx-1" (click)="signInWithVK()"><span class="fa fa-vk"></span></button>
+      <button class="btn btn-social-icon btn-google mx-1" (click)="signInWithGoogle()"><span class="fab fa-google"></span></button>
+      <button class="btn btn-social-icon btn-facebook mx-1" (click)="signInWithFB()"><span class="fab fa-facebook"></span></button>
+      <button class="btn btn-social-icon btn-amazon mx-1" (click)="signInWithAmazon()"><span class="fab fa-amazon"></span></button>
+      <button class="btn btn-social-icon btn-amazon mx-1" (click)="signInWithVK()"><span class="fab fa-vk"></span></button>
+      <button class="btn btn-social-icon btn-microsoft mx-1" (click)="signInWithMicrosoft()"><span class="fab fa-microsoft"></span></button>
     </div>
   </div>
   <div *ngIf="user" class="card text-center">

--- a/src/app/demo/demo.component.ts
+++ b/src/app/demo/demo.component.ts
@@ -7,6 +7,7 @@ import {
   FacebookLoginProvider,
   AmazonLoginProvider,
   VKLoginProvider,
+  MicrosoftLoginProvider
 } from 'lib';
 
 @Component({
@@ -40,6 +41,10 @@ export class DemoComponent implements OnInit {
 
   signInWithVK(): void {
     this.authService.signIn(VKLoginProvider.PROVIDER_ID);
+  }
+
+  signInWithMicrosoft(): void {
+    this.authService.signIn(MicrosoftLoginProvider.PROVIDER_ID);
   }
 
   signOut(): void {

--- a/src/index.html
+++ b/src/index.html
@@ -21,8 +21,9 @@
     integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn"
     crossorigin="anonymous"></script>
 
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
-    integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css"
+    integrity="sha512-+4zCK9k+qNFUR5X+cKL9EIR+ZOhtIloNl9GIKS57V1MyNsYpYcUrUeQc9vNfzsWfV28IaLL3i96P9sdNyeRssA=="
+    crossorigin="anonymous" />
 
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-social/5.1.1/bootstrap-social.min.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
Resolves: https://github.com/abacritt/angularx-social-login/issues/306

Logout for the Microsoft provider has to navigate to `login.microsoftonline.com` to fully end the user session and log them out.  I opened an issue against the MSAL library ( https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/2563 ) so worst case we could do that in a popup like the login and they seem to have had that request a few times already.

**Configuration**
Default configuration looks like the following which is just a flattening of commonly used properties from the [MSAL configuration object](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/configuration.md).

```typescript
const COMMON_AUTHORITY: string = 'https://login.microsoftonline.com/common/';

let microsoftOptions : MicrosoftOptions = {
  redirect_uri: location.origin,
  authority: COMMON_AUTHORITY,
  scopes: ['openid', 'profile', 'User.Read'],
  knownAuthorities: [],
  protocolMode: ProtocolMode.AAD,
  clientCapabilities: [],
  cacheLocation: 'sessionStorage'
};
```



**Notes**
I set up the Microsoft app with `https://localhost:4200/` as a valid origin so for development/testing I was using `ng serve --ssl true`.  HTTPS is required for Facebook authentication now but the existing registration that's used for the demo app doesn't seem to have HTTPS from localhost listed as a valid origin (you can see FB errors in the console when loading the demo from `http://localhost:4200`).  The Microsoft registration seems to work with HTTP or HTTPS

I also bumped the demo app to use Font Awesome 5.15.1 so I could use the Microsoft brand icon.