### PR TITLE
MS Provider - prompt option

### DIFF
--- a/microsoft-provider.md
+++ b/microsoft-provider.md
@@ -26,3 +26,4 @@ The second argument can have the following fields (all fields are optional):
 |protocolMode|ProtocolMode|The protocol to use, AAD or OIDC|`ProtocolMode.AAD`|
 |clientCapabilities|string[]|Array of capabilities to be added to all network requests as part of the xms_cc claims request|null|
 |cacheLocation|string|Location of token cache in browser|`'sessionStorage'`|
+|prompt|string|Indicates the type of user interaction that is required. The only valid values at this time are `login`, `none`, `select_account`, and `consent`|`none`

--- a/projects/lib/src/providers/microsoft-login-provider.ts
+++ b/projects/lib/src/providers/microsoft-login-provider.ts
@@ -21,7 +21,8 @@ export type MicrosoftOptions = {
   protocolMode?: ProtocolMode,
   clientCapabilities?: string[],
   cacheLocation?: string,
-  scopes?: string[]
+  scopes?: string[],
+  prompt?: string,
 };
 
 // Collection of internal MSAL interfaces from: https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-browser/src
@@ -52,6 +53,7 @@ interface MSALLoginRequest {
   sid?: string;
   loginHint?: string;
   domainHint?: string;
+  prompt?: string;
 }
 
 interface MSALLoginResponse {
@@ -205,7 +207,8 @@ export class MicrosoftLoginProvider extends BaseLoginProvider {
 
   async signIn(): Promise<SocialUser> {
     const loginResponse = await this._instance.loginPopup({
-      scopes: this.initOptions.scopes
+      scopes: this.initOptions.scopes,
+      prompt: this.initOptions.prompt,
     });
     return await this.getSocialUser(loginResponse);
   }


### PR DESCRIPTION
Add `prompt` option to indicate user interaction type during login process.
[Send Sign In request from MS documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow#send-the-sign-in-request)