### PR TITLE
Rethrow provider login errors

### DIFF
--- a/projects/lib/src/socialauth.service.ts
+++ b/projects/lib/src/socialauth.service.ts
@@ -95,7 +95,10 @@ export class SocialAuthService {
                 this._authState.next(user);
                 loggedIn = true;
               })
-              .catch(console.debug);
+              .catch((error) => {
+                console.debug(error);
+                throw error;
+              });
           });
           Promise.all(loginStatusPromises).catch(() => {
             if (!loggedIn) {


### PR DESCRIPTION
Allow the error to propagate so the following catch callback can send null into the authState