### PR TITLE
fix(readme): img src when using google provider

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -159,7 +159,7 @@ export class DemoComponent implements OnInit {
 ### Display the user information
 
 ```html
-<img src="{{ user.photoUrl }}">
+<img src="{{ user.photoUrl }}" referrerpolicy="no-referrer">
 <div>
   <h4>{{ user.name }}</h4>
   <p>{{ user.email }}</p>


### PR DESCRIPTION
Images won't show and a 403 is generated when using the photoUrl of google.
See: https://stackoverflow.com/questions/40570117/http403-forbidden-error-when-trying-to-load-img-src-with-google-profile-pic

This fixes that in the readme so the sample works OOB.