### PR TITLE
Correct google init action if an error is seen

### DIFF
--- a/projects/lib/src/providers/google-login-provider.ts
+++ b/projects/lib/src/providers/google-login-provider.ts
@@ -32,7 +32,14 @@ export class GoogleLoginProvider extends BaseLoginProvider {
                   resolve();
                 })
                 .catch((err: any) => {
-                  reject(err);
+                  if ((err.details as string).includes('deprecated')) {
+                    // we can still use the instance as it's ready.
+                    this.auth2 = gapi.auth2.getAuthInstance();
+                    console.error(err)
+                    resolve();
+                  } else {
+                    reject(err);
+                  }
                 });
             });
           }


### PR DESCRIPTION
Google is now throwing an error if deprecated APIs are used. This change cures this problem by still allowing the use of the auth object. All other errors are still rejected. After this change the Google provider will need to be completely re-written for the new API. Note the new API is not compatible with the old one and so there will have to be a fall back period whilst users upgrade.