### PR TITLE
Support all Angular 13 versions

### DIFF
--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -31,8 +31,8 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "@angular/common": "^13.2.6",
-    "@angular/core": "^13.2.6"
+    "@angular/common": "^13.0.0",
+    "@angular/core": "^13.0.0"
   },
   "homepage": "https://github.com/abacritt/angularx-social-login#readme",
   "main": "bundles/abacrit-angularx-social-login.umd.js",


### PR DESCRIPTION
The peer dependency constraint was requiring the version to be >= 13.2.6, but there seem to be no actual need for the changes introduced after the release.

Fixes https://github.com/abacritt/angularx-social-login/issues/463