### PR TITLE
fixes "atob" decode failed to execute

### DIFF
--- a/projects/lib/src/providers/google-login-provider.ts
+++ b/projects/lib/src/providers/google-login-provider.ts
@@ -186,6 +186,16 @@ export class GoogleLoginProvider extends BaseLoginProvider {
   }
 
   private decodeJwt(idToken: string): Record<string, string | undefined> {
-    return JSON.parse(window.atob(idToken.split('.')[1]));
+    const base64Url = idToken.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+      window.atob(base64)
+        .split("")
+        .map(function (c) {
+          return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+        })
+        .join("")
+    );
+    return JSON.parse(jsonPayload);
   }
 }


### PR DESCRIPTION
For Google login, it fails when decoding the jwt token in multibyte languages.
Error in function decodeJwt:
```
Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at GoogleLoginProvider.decodeJwt (http://localhost:4200/main.js:537:30)
    at GoogleLoginProvider.createSocialUser (http://localhost:4200/main.js:526:26)
```

