### PR TITLE
[Add] itp_support attr to Google btn

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -124,7 +124,7 @@ Options:
 | width          | string    |  '200 - 400 '                                             |               |
 | theme          | string    |  'outline','filled_blue' or 'filled_black'                | 'outline'     |
 | logo_alignment | string    |  'left' or 'center'                                       | 'left'        |
-
+| itp_support    | boolean   |  true or false                                            | true          |
 
 
 

--- a/projects/lib/src/directives/google-signin-button.directive.ts
+++ b/projects/lib/src/directives/google-signin-button.directive.ts
@@ -26,6 +26,9 @@ export class GoogleSigninButtonDirective {
   logo_alignment: 'left' | 'center' = 'left';
 
   @Input()
+  itp_support: boolean = true;
+
+  @Input()
   width: string = '';
 
   @Input()
@@ -57,7 +60,7 @@ export class GoogleSigninButtonDirective {
             theme: this.theme,
             logo_alignment: this.logo_alignment,
             locale: this.locale,
-            
+            itp_support: this.itp_support,
           });
         }
       });


### PR DESCRIPTION
I added `itp_support` boolean attribute to `GoogleSigninButtonDirective`. This allows users to disable the One Tap window in case we just want the button.

Sources :
[HTML API reference : data-itp_support](https://developers.google.com/identity/gsi/web/reference/html-reference#data-itp_support)
[Understand One Tap User Experience : Upgraded UX on ITP browsers](https://developers.google.com/identity/gsi/web/guides/features#upgraded_ux_on_itp_browsers)

Example :
![One Tap UX ](https://developers.google.com/static/identity/gsi/web/images/warm-welcome.png)

