### PR TITLE
[Fix] move itp_support from google btn to conf

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -115,16 +115,15 @@ Check out the [Google button generator](https://developers.google.com/identity/g
 <asl-google-signin-button type='icon' size='medium'></asl-google-signin-button>
 ```
 Options:
-|  Name          | Type      | Value                                                     | Default       |   
+|  Name          | Type      | Value                                                     | Default       |
 |----------------|-----------|-----------------------------------------------------------|---------------|
 | type           | string    | 'icon' or 'standard'                                      | 'icon'        |
 | size           | string    |  'small', 'medium' or 'large'                             | 'medium'      |
-| shape          | string    |  'square','circle','pill' or 'rectangular'                | 'rectangular' | 
+| shape          | string    |  'square','circle','pill' or 'rectangular'                | 'rectangular' |
 | text           | string    |  'signin_with','signup_with'or 'continue_with'            | 'signin_with' |
 | width          | string    |  '200 - 400 '                                             |               |
 | theme          | string    |  'outline','filled_blue' or 'filled_black'                | 'outline'     |
 | logo_alignment | string    |  'left' or 'center'                                       | 'left'        |
-| itp_support    | boolean   |  true or false                                            | true          |
 
 
 

--- a/projects/lib/src/directives/google-signin-button.directive.ts
+++ b/projects/lib/src/directives/google-signin-button.directive.ts
@@ -26,9 +26,6 @@ export class GoogleSigninButtonDirective {
   logo_alignment: 'left' | 'center' = 'left';
 
   @Input()
-  itp_support: boolean = true;
-
-  @Input()
   width: string = '';
 
   @Input()
@@ -60,7 +57,6 @@ export class GoogleSigninButtonDirective {
             theme: this.theme,
             logo_alignment: this.logo_alignment,
             locale: this.locale,
-            itp_support: this.itp_support,
           });
         }
       });

--- a/projects/lib/src/providers/google-login-provider.ts
+++ b/projects/lib/src/providers/google-login-provider.ts
@@ -60,8 +60,9 @@ export class GoogleLoginProvider extends BaseLoginProvider {
               callback: ({ credential }) => {
                 const socialUser = this.createSocialUser(credential);
                 this._socialUser.next(socialUser);
-              }, 
-              prompt_parent_id: this.initOptions?.prompt_parent_id
+              },
+              prompt_parent_id: this.initOptions?.prompt_parent_id,
+              itp_support: this.initOptions.oneTapEnabled
             });
 
             if (this.initOptions.oneTapEnabled) {


### PR DESCRIPTION
Reverts abacritt/angularx-social-login#581 thanks to [kattoshi](https://github.com/kattoshi)

Move `itp_support` from [GsiButtonConfiguration](https://developers.google.com/identity/gsi/web/reference/js-reference#GsiButtonConfiguration) to [IdConfiguration](https://developers.google.com/identity/gsi/web/reference/js-reference#IdConfiguration)