### PR TITLE
SocialUser is stored in Local Storage

### DIFF
--- a/projects/lib/src/socialauth.service.ts
+++ b/projects/lib/src/socialauth.service.ts
@@ -109,6 +109,16 @@ export class SocialAuthService {
               this._authState.next(null);
             }
           });
+        } else {
+          // if autoLogin is not enabled, try to retrieve the Google SocialUser from localState
+          this.providers.get(GoogleLoginProvider.PROVIDER_ID).getLoginStatus().then((user: SocialUser) => {
+            if (user !== null) {
+              this.setUser(user, GoogleLoginProvider.PROVIDER_ID)
+            }
+          })
+          .catch(reason => {
+            // nobody logged in, nothing to do
+          })
         }
 
         this.providers.forEach((provider, key) => {


### PR DESCRIPTION
As mentioned in issues #586 and #522, when using the Google provider, a reload of the page will effectively log-out the user. This is because the SocialUser (or the id token) are only stored in memory in the SocialAuthService.

In this PR, every successfull authentication is stored in Local Storage and will therefore also survive a page reload. After a page reload, the SocialAuthService checks first if there are valid Google credentials and restores them to the service. Also, a timer is started, that will refresh the user when the id token becomes invalid.

Feel free to comment or add suggestions, this is my first time contributing :)