### PR TITLE
Add `continue_with` to `text` allowed values

### DIFF
--- a/projects/lib/src/directives/google-signin-button.directive.ts
+++ b/projects/lib/src/directives/google-signin-button.directive.ts
@@ -14,7 +14,7 @@ export class GoogleSigninButtonDirective {
   size: 'small' | 'medium' | 'large' = 'medium';
 
   @Input()
-  text: 'signin_with' | 'signup_with' = 'signin_with';
+  text: 'signin_with' | 'signup_with' | 'continue_with' = 'signin_with';
 
   @Input()
   shape: 'square' | 'circle' | 'pill' | 'rectangular' = 'rectangular';


### PR DESCRIPTION
Sing in with Google section on readme https://github.com/abacritt/angularx-social-login#sign-in-with-google has the following available options for `text`


text | string | 'signin_with','signup_with'or 'continue_with' | 'signin_with'
-- | -- | -- | --

This PR will fix missing `continue_with` type casting to the `text` input.