### PR TITLE
fix: changing rxjs operators import

### DIFF
--- a/projects/lib/src/directives/google-signin-button.directive.ts
+++ b/projects/lib/src/directives/google-signin-button.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, Input } from '@angular/core';
-import { take } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { SocialAuthService } from '../socialauth.service';
 
 @Directive({

--- a/projects/lib/src/providers/google-login-provider.ts
+++ b/projects/lib/src/providers/google-login-provider.ts
@@ -1,7 +1,8 @@
 import { BaseLoginProvider } from '../entities/base-login-provider';
 import { SocialUser } from '../entities/social-user';
 import { EventEmitter } from '@angular/core';
-import { BehaviorSubject, filter, skip, take } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
+import { filter, skip, take } from 'rxjs/operators';
 
 export interface GoogleInitOptions {
   /**


### PR DESCRIPTION
fixing errors by changind import path:
- export 'take' (imported as 'take') was not found in 'rxjs'
- export 'take' (imported as 'skip') was not found in 'rxjs'
- export 'take' (imported as 'filter') was not found in 'rxjs'

found while installing the library in an angular 15 project