### PR TITLE
Add option use_fedcm_for_prompt with same value than oneTapEnabled

### DIFF
--- a/projects/lib/src/providers/google-login-provider.ts
+++ b/projects/lib/src/providers/google-login-provider.ts
@@ -77,7 +77,8 @@ export class GoogleLoginProvider extends BaseLoginProvider {
                 this._socialUser.next(socialUser);
               },
               prompt_parent_id: this.initOptions?.prompt_parent_id,
-              itp_support: this.initOptions.oneTapEnabled
+              itp_support: this.initOptions.oneTapEnabled,
+              use_fedcm_for_prompt: this.initOptions.oneTapEnabled
             });
 
             if (this.initOptions.oneTapEnabled) {


### PR DESCRIPTION
Developers will be migrated by default starting April 2024. Opt-in to FedCM (set [boolean flag to true](https://notifications.google.com/g/p/ANiao5ow5Tla6OVb28ojCX4O6gVIvYJVpJTgpO5ZqDn8ClkSy03xsGveEp8qriF6VMrcb4KMicqLdlW8hY9Ik9csZZykXFDIXQ0jD9YJYimTt9-2wTbRow5SekUllktEidF4Dq6LgFoT-dHNt8qA3MrJQuRpe8kdFFWyHEN2B_HRfjb_29ub6EGzBM0bH7j2g_SeVY0Bv2bNC5KRs3I9mopu_YnHK1bkog8e8L7-PudJm4WeOegzbX7PMj03Du8jcNQJWveTpXhX1kFblKHt)) to test and make any necessary changes to ensure a smooth transition.

Developers using [Automatic Sign-in](https://notifications.google.com/g/p/ANiao5oRGQb2zweGv-Ty4P1J8wmf99Q-wEMNk1tRoRXs15yH7wF7A24O7anQQmZEC8oAlWftKGPH4oX4aK-Jn8luOqzpuEFf1sTMoZbNrVBK7-LkEPjSWw2bMpMEgWyLNMPRI6Xw6pvE8qVql9N4VAUsCO1Vu89-1u22_k_83gz9zHmeYGQriHT1BONJqaUl-ha45YESNZhoosXHXmuITC-JxJRNb0I-7jAMa45GTB54D8z_30pj9a5uKcO_Qofn4FClqbsWbqPga0U7cPJu) feature should migrate to FedCM [as soon as possible](https://notifications.google.com/g/p/ANiao5rMIZP4k4Se2-MbvqLaIKouDKt9rlpGlBL_AAZI9y3srDoy0UHC9a1Ebk9CdCP88e_JKlobyo1scB_Co-3hr8FOtX1PTka1i-i20uKpX7AlD143ijknCLqBToFXLALbTg9na4Y6H8oKZVuql-7nJvKOVw6UvV7Gj-StELAp5sSbnJSX1qqjR-Xtp9qHMEgVDPDnKvXRqsHrfDLzAQ3wz-oNomAAQRv-gCjkPZTyiINMD7USsftXPhSVAbujHp00XZtmhAaKMvtryGPPU6E) to reduce any potential impact on conversion rates.

If you need more time to verify FedCM functions properly on your site and make changes to your code, set the [boolean flag to false](https://notifications.google.com/g/p/ANiao5ow5Tla6OVb28ojCX4O6gVIvYJVpJTgpO5ZqDn8ClkSy03xsGveEp8qriF6VMrcb4KMicqLdlW8hY9Ik9csZZykXFDIXQ0jD9YJYimTt9-2wTbRow5SekUllktEidF4Dq6LgFoT-dHNt8qA3MrJQuRpe8kdFFWyHEN2B_HRfjb_29ub6EGzBM0bH7j2g_SeVY0Bv2bNC5KRs3I9mopu_YnHK1bkog8e8L7-PudJm4WeOegzbX7PMj03Du8jcNQJWveTpXhX1kFblKHt). This will temporarily exempt your traffic from using FedCM. Regardless of the flag selection, starting on January 4, 2024, users that are part of Chrome’s [Tracking Protection](https://notifications.google.com/g/p/ANiao5rsU7PESDA6mvCnUPegNnpd1VrqlspqQaduehQLYPvhV2K8BnrEj_tJTb2NKqnvisDqspv46QFVBAC2ce0FtvLy3U6DOiPe6qwY1eXNYMbcAL2xqw0ego8nHP1mylD1A6MnmRfKWRvWd0W7HvWbHigXNj4Th-CdvZh_nQAKlq9bRndXnG7i7r2fO-kSUyMxGuNp4fOkkb6Sg1yQ92J9hQ6CDE_ta86yxLkkGXYOgngY2Wwtixk1scK1ugvwueP1rN5WEQ) rollout will have limited access to third-party cookies, and unless FedCM is enabled, One Tap and Automatic sign-in will not be displayed to these users.

Reviewing the required changes:https://developers.google.com/identity/gsi/web/guides/fedcm-migration#migrate_your_web_app
I think that we will need at least a new property on https://developers.google.com/identity/gsi/web/reference/js-reference#IdConfiguration

I have used same value that for oneTapEnabled as both options are related
